### PR TITLE
Add pfsspy heritage docs page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ intersphinx_mapping = {
     "streamtracer": ("https://streamtracer.readthedocs.io/en/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "reproject": ("https://reproject.readthedocs.io/en/stable/", None),
+    "pfsspy": ("https://pfsspy.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/heritage.rst
+++ b/docs/heritage.rst
@@ -7,7 +7,7 @@ Code Heritage
 
 As of initial release, the main component of ``sunkit-magex`` (`sunkit_magex.pfss`) is forked from `pfsspy` package (archived as of August 24, 2023).
 `pfsspy` implemented the Potential Field Source Surface (PFSS) model, a widely used method to extrapolate the magnetic fields of the solar corona.
-`pfsspy` was developed, integrated with `sunpy` and maintained by `David Stansby <https://www.davidstansby.com/>`_, based on an `original PFSS implementation <https://doi.org/10.5281/zenodo.1472183>`_  by `Anthony Yeates <https://www.maths.dur.ac.uk/users/anthony.yeates/>`_.
+`pfsspy` was developed, integrated with `sunpy` and maintained by `David Stansby <https://www.davidstansby.com/>`__, based on an `original PFSS implementation <https://doi.org/10.5281/zenodo.1472183>`__  by `Anthony Yeates <https://www.maths.dur.ac.uk/users/anthony.yeates/>`__.
 
 Details of the numerical methods underlying the solver can be found in :any:`numerical_methods_pfss/index`.
 

--- a/docs/heritage.rst
+++ b/docs/heritage.rst
@@ -5,23 +5,16 @@ Code Heritage
 ``pfsspy``
 ==========
 
-As of initial release, the main component of ``sunkit-magex`` (`sunkit_magex.pfss`) is 
-forked from `pfsspy` package (archived as of August 24, 2023). `pfsspy` 
-implemented the Potential Field Source Surface (PFSS) model, a widely used
-method to extrapolate the magnetic fields of the solar corona. ``pfsspy`` was 
-developed, integrated with `sunpy` and maintained by 
-`David Stansby <https://www.davidstansby.com/>`_
-based on an `original PFSS implementation <https://doi.org/10.5281/zenodo.1472183>`_ 
-by `Anthony Yeates <https://www.maths.dur.ac.uk/users/anthony.yeates/>`_.
+As of initial release, the main component of ``sunkit-magex`` (`sunkit_magex.pfss`) is forked from `pfsspy` package (archived as of August 24, 2023).
+`pfsspy` implemented the Potential Field Source Surface (PFSS) model, a widely used method to extrapolate the magnetic fields of the solar corona.
+`pfsspy` was developed, integrated with `sunpy` and maintained by `David Stansby <https://www.davidstansby.com/>`_, based on an `original PFSS implementation <https://doi.org/10.5281/zenodo.1472183>`_  by `Anthony Yeates <https://www.maths.dur.ac.uk/users/anthony.yeates/>`_.
 
-Details of the numerical methods underlying the solver
-can be found in :any:`numerical_methods_pfss/index`.
+Details of the numerical methods underlying the solver can be found in :any:`numerical_methods_pfss/index`.
 
 Citing
 ------
 
-If you use `sunkit_magex.pfss` in work that results in publication, please cite the
-original ``pfsspy`` Journal of Open Source Software paper at https://doi.org/10.21105/joss.02732.
+If you use `sunkit_magex.pfss` in work that results in publication, please cite the original ``pfsspy`` Journal of Open Source Software paper at https://doi.org/10.21105/joss.02732.
 A ready made bibtex entry is
 
 .. code:: bibtex
@@ -38,8 +31,3 @@ A ready made bibtex entry is
     title = {pfsspy: A Python package for potential field source surface modelling},
     journal = {Journal of Open Source Software}
   }
-
-
-
-
-

--- a/docs/heritage.rst
+++ b/docs/heritage.rst
@@ -1,0 +1,45 @@
+*************
+Code Heritage
+*************
+
+``pfsspy``
+==========
+
+As of initial release, the main component of ``sunkit-magex`` (`sunkit_magex.pfss`) is 
+forked from `pfsspy` package (archived as of August 24, 2023). `pfsspy` 
+implemented the Potential Field Source Surface (PFSS) model, a widely used
+method to extrapolate the magnetic fields of the solar corona. ``pfsspy`` was 
+developed, integrated with `sunpy` and maintained by 
+`David Stansby <https://www.davidstansby.com/>`_
+based on an `original PFSS implementation <https://doi.org/10.5281/zenodo.1472183>`_ 
+by `Anthony Yeates <https://www.maths.dur.ac.uk/users/anthony.yeates/>`_.
+
+Details of the numerical methods underlying the solver
+can be found in :any:`numerical_methods_pfss/index`.
+
+Citing
+------
+
+If you use `sunkit_magex.pfss` in work that results in publication, please cite the
+original ``pfsspy`` Journal of Open Source Software paper at https://doi.org/10.21105/joss.02732.
+A ready made bibtex entry is
+
+.. code:: bibtex
+
+  @article{Stansby2020,
+    doi = {10.21105/joss.02732},
+    url = {https://doi.org/10.21105/joss.02732},
+    year = {2020},
+    publisher = {The Open Journal},
+    volume = {5},
+    number = {54},
+    pages = {2732},
+    author = {David Stansby and Anthony Yeates and Samuel T. Badman},
+    title = {pfsspy: A Python package for potential field source surface modelling},
+    journal = {Journal of Open Source Software}
+  }
+
+
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,11 @@ This is the documentation for sunkit-magex.
    :caption: Contents:
 
    installing
+   heritage
    generated/gallery/index
-   reference/index
+   reference/index   
    performance
    numerical_methods_pfss/index.rst
    synoptic_fits
+   
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,7 @@ This is the documentation for sunkit-magex.
    installing
    heritage
    generated/gallery/index
-   reference/index   
+   reference/index
    performance
    numerical_methods_pfss/index.rst
    synoptic_fits
-   
-


### PR DESCRIPTION
## PR Description

Add a new docs page which describes the heritage of `sunkit-magex.pfss` from `pfsspy`. Addresses action listed in #36 

Changes:
- add docs/heritage.rst with new content
- add index list for new page in docs/index.rst
- add `pfsspy` link in sphinx config to allow linking to its readthedocs

Current issue with PR - new entry appears in landing page table of contents when tested with tox locally but not in html sidebar
