### PR TITLE
Update open_closed_field_map.py

### DIFF
--- a/examples/using_sunkit_magex_pfss/open_closed_field_map.py
+++ b/examples/using_sunkit_magex_pfss/open_closed_field_map.py
@@ -6,7 +6,6 @@ Creating an open/closed field map on the solar surface.
 """
 import matplotlib.colors as mcolor
 import matplotlib.pyplot as plt
-import numpy as np
 
 import astropy.constants as const
 import astropy.units as u
@@ -45,8 +44,8 @@ pfss_out = pfss.pfss(pfss_in)
 coords = sunpy.map.all_coordinates_from_map(gong_map)
 ny, nx = gong_map.data.shape
 
-lon = coords.lon.wrap_at(360*u.deg)    
-lat = coords.lat                      
+lon = coords.lon.wrap_at(360*u.deg)
+lat = coords.lat
 
 seeds = SkyCoord(lon.ravel(), lat.ravel(), const.R_sun, frame=pfss_out.coordinate_frame)
 
@@ -65,7 +64,7 @@ wcs_header = gong_map.wcs.to_header(relax=True)
 wcs_header['NAXIS']  = 2
 wcs_header['NAXIS1'] = pols.shape[1]
 wcs_header['NAXIS2'] = pols.shape[0]
-wcs_header['BTYPE']  = 'polarity' 
+wcs_header['BTYPE']  = 'polarity'
 wcs_header['BUNIT']  = ''           # dimensionless
 
 pols_map = sunpy.map.Map(pols.astype(float), wcs_header)


### PR DESCRIPTION
## Fixes alignment issue in plots.



In the example for the plotting of an open closed field map, the gong magnetogram and open/closed field image where misaligend due to the placement of the seed points. This means the two plots aren't directly comparable and also leads to added complexity if the information is wanting to be combined in a single plot.

I have made modifiications the original script to:

- Set seed points so that they correspond to pixel locations in gong magnetogram.
- Create a polarity map with coordinates that are the same as the gong magnetogram. 
- Set up a polarity map header has minimal information, enough for the plot to work.

The result is a plot for the polarity map that is directly comparable to the gong map plot above it. 

This is in relation to #112 
